### PR TITLE
Fix maven warning.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.1</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>


### PR DESCRIPTION
Fixes the "'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing." warning from maven.